### PR TITLE
[SortableBehaviorBundle] Add `SortableAdminTrait` to avoid the extend of `AbstractSortableAdmin`

### DIFF
--- a/packages/sortable-behavior-bundle/composer.json
+++ b/packages/sortable-behavior-bundle/composer.json
@@ -36,7 +36,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpunit/phpunit": "^9.5",
         "psr/container": "^1.1 || ^2.0",
-        "runroom-packages/testing": "^0.16",
+        "runroom-packages/testing": "^0.15",
         "sonata-project/admin-bundle": "^3.103 || ^4.9",
         "sonata-project/doctrine-orm-admin-bundle": "^3.34 || ^4.0",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",

--- a/packages/sortable-behavior-bundle/composer.json
+++ b/packages/sortable-behavior-bundle/composer.json
@@ -36,7 +36,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpunit/phpunit": "^9.5",
         "psr/container": "^1.1 || ^2.0",
-        "runroom-packages/testing": "^0.15",
+        "runroom-packages/testing": "^0.16",
         "sonata-project/admin-bundle": "^3.103 || ^4.9",
         "sonata-project/doctrine-orm-admin-bundle": "^3.34 || ^4.0",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",

--- a/packages/sortable-behavior-bundle/src/Admin/AbstractSortableAdmin.php
+++ b/packages/sortable-behavior-bundle/src/Admin/AbstractSortableAdmin.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Runroom\SortableBehaviorBundle\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
 /**
  * @template T of object
@@ -24,21 +22,5 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
  */
 abstract class AbstractSortableAdmin extends AbstractAdmin
 {
-    /**
-     * @param mixed[] $sortValues
-     */
-    protected function configureDefaultSortValues(array &$sortValues): void
-    {
-        $sortValues['_sort_by'] = 'position';
-    }
-
-    /**
-     * @todo: Simplify this when dropping support for Sonata 3
-     *
-     * @param RouteCollection|RouteCollectionInterface $collection
-     */
-    protected function configureRoutes(object $collection): void
-    {
-        $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
-    }
+    use SortableAdminTrait;
 }

--- a/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
+++ b/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
@@ -6,6 +6,15 @@ namespace Runroom\SortableBehaviorBundle\Admin;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
+/*
+ * This file is part of the Runroom package.
+ *
+ * (c) Runroom <runroom@runroom.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 trait SortableAdminTrait
 {
     /**

--- a/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
+++ b/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
@@ -18,7 +18,12 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
 trait SortableAdminTrait
 {
-    abstract public function getRouterIdParameter(): string;
+    /**
+     * @todo: Add return typehint when dropping support for Sonata 3
+     *
+     * @return string
+     */
+    abstract public function getRouterIdParameter();
 
     /**
      * @param mixed[] $sortValues

--- a/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
+++ b/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
@@ -1,10 +1,6 @@
 <?php
+
 declare(strict_types=1);
-
-namespace Runroom\SortableBehaviorBundle\Admin;
-
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
 /*
  * This file is part of the Runroom package.
@@ -15,8 +11,15 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
  * file that was distributed with this source code.
  */
 
+namespace Runroom\SortableBehaviorBundle\Admin;
+
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
 trait SortableAdminTrait
 {
+    abstract public function getRouterIdParameter(): string;
+
     /**
      * @param mixed[] $sortValues
      */
@@ -34,6 +37,4 @@ trait SortableAdminTrait
     {
         $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
     }
-
-    abstract public function getRouterIdParameter(): string;
 }

--- a/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
+++ b/packages/sortable-behavior-bundle/src/Admin/SortableAdminTrait.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Runroom\SortableBehaviorBundle\Admin;
+
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
+trait SortableAdminTrait
+{
+    /**
+     * @param mixed[] $sortValues
+     */
+    protected function configureDefaultSortValues(array &$sortValues): void
+    {
+        $sortValues['_sort_by'] = 'position';
+    }
+
+    /**
+     * @todo: Simplify this when dropping support for Sonata 3
+     *
+     * @param RouteCollection|RouteCollectionInterface $collection
+     */
+    protected function configureRoutes(object $collection): void
+    {
+        $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
+    }
+
+    abstract public function getRouterIdParameter(): string;
+}


### PR DESCRIPTION
Moved from https://github.com/Runroom/RunroomSortableBehaviorBundle/pull/2