### PR TITLE
[RunroomSortableBehaviorBundle] Fix drag and drop get position

### DIFF
--- a/packages/sortable-behavior-bundle/src/Service/AbstractPositionHandler.php
+++ b/packages/sortable-behavior-bundle/src/Service/AbstractPositionHandler.php
@@ -68,6 +68,9 @@ abstract class AbstractPositionHandler implements PositionHandlerInterface
                 $newPosition = $lastPosition;
                 break;
         }
+        if (is_numeric($movePosition)) {
+            $newPosition = (int)$movePosition;
+        }
 
         return max(0, min($newPosition, $lastPosition));
     }

--- a/packages/sortable-behavior-bundle/tests/Functional/AbstractSortableAdminTest.php
+++ b/packages/sortable-behavior-bundle/tests/Functional/AbstractSortableAdminTest.php
@@ -57,5 +57,17 @@ class AbstractSortableAdminTest extends WebTestCase
         static::assertSame(3, $sortableEntity2->getPosition());
         static::assertSame(1, $sortableEntity3->getPosition());
         static::assertSame(0, $sortableEntity4->getPosition());
+
+        $client->request('GET', '/tests/app/sortableentity/' . $sortableEntity3->getId() . '/move/3');
+
+        $sortableEntity1->refresh();
+        $sortableEntity2->refresh();
+        $sortableEntity3->refresh();
+        $sortableEntity4->refresh();
+
+        static::assertSame(1, $sortableEntity1->getPosition());
+        static::assertSame(2, $sortableEntity2->getPosition());
+        static::assertSame(3, $sortableEntity3->getPosition());
+        static::assertSame(0, $sortableEntity4->getPosition());
     }
 }

--- a/packages/sortable-behavior-bundle/tests/Unit/AbstractPositionHandlerTest.php
+++ b/packages/sortable-behavior-bundle/tests/Unit/AbstractPositionHandlerTest.php
@@ -56,6 +56,10 @@ class AbstractPositionHandlerTest extends TestCase
         $this->entity->setPosition($this->positionHandler->getPosition($this->entity, 'random', $lastPosition));
 
         static::assertSame(0, $this->entity->getPosition());
+
+        $this->entity->setPosition($this->positionHandler->getPosition($this->entity, '5', $lastPosition));
+
+        static::assertSame(5, $this->entity->getPosition());
     }
 }
 


### PR DESCRIPTION
For drag and drop functionallity, from controller could come new position as numeric ($movePosition). In such case getPosition return same position of object and as result nothing is changed. https://github.com/Runroom/RunroomSortableBehaviorBundle/blob/master/src/Action/MoveAction.php#L64