### PR TITLE
[RunroomSortableBehaviorBundle] Add PHP 8 attributes to Sortable Trait

### DIFF
--- a/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
+++ b/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
@@ -22,6 +22,8 @@ trait Sortable
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
+    #[Gedmo\SortablePosition]
+    #[ORM\Column(type: 'integer')]
     private ?int $position = null;
 
     public function setPosition(?int $position): self

--- a/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
+++ b/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
@@ -23,7 +23,7 @@ trait Sortable
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column('position', 'integer')]
     private ?int $position = null;
 
     public function setPosition(?int $position): self

--- a/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
+++ b/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
@@ -23,7 +23,7 @@ trait Sortable
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
-    #[ORM\Column('position', 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private ?int $position = null;
 
     public function setPosition(?int $position): self

--- a/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
+++ b/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
@@ -17,6 +17,9 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
+/**
+ * Keep annotations and attributes since this class is mean to be used by end user entities.
+ */
 trait Sortable
 {
     /**

--- a/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
+++ b/packages/sortable-behavior-bundle/src/Behaviors/Sortable.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Runroom\SortableBehaviorBundle\Behaviors;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 


### PR DESCRIPTION
While migrating to doctrine attributes `position` field missed
`Unrecognized field: position`

The PR adds required attributes. 
Please make a new tag after merge.
UPD: CI failed not of PR changes reason 